### PR TITLE
MOR 1947: morgen tasks obsidian plugin hide ids in reading mode

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,23 +1,22 @@
 {
-    "root": true,
-    "parser": "@typescript-eslint/parser",
-    "env": { "node": true },
-    "plugins": [
-      "@typescript-eslint"
-    ],
-    "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/eslint-recommended",
-      "plugin:@typescript-eslint/recommended"
-    ], 
-    "parserOptions": {
-        "sourceType": "module"
-    },
-    "rules": {
-      "no-unused-vars": "off",
-      "@typescript-eslint/no-unused-vars": ["error", { "args": "none" }],
-      "@typescript-eslint/ban-ts-comment": "off",
-      "no-prototype-builtins": "off",
-      "@typescript-eslint/no-empty-function": "off"
-    } 
+  "parser": "@typescript-eslint/parser",
+  "extends": ["prettier", "eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "parserOptions": {
+    "ecmaVersion": 2018,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "prefer-destructuring": 1,
+    "@typescript-eslint/explicit-member-accessibility": 0,
+    "@typescript-eslint/explicit-function-return-type": 0,
+    "@typescript-eslint/no-parameter-properties": 0,
+    "@typescript-eslint/interface-name-prefix": 0,
+    "@typescript-eslint/explicit-module-boundary-types": 0,
+    "@typescript-eslint/no-explicit-any": 0,
+    "@typescript-eslint/ban-types": 0,
+    "@typescript-eslint/no-var-requires": 0,
+    "@typescript-eslint/no-unused-vars": "warn",
+    "@typescript-eslint/ban-ts-comment": 0
   }
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "printWidth": 100
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,11 @@
+import globals from "globals";
+import pluginJs from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+
+export default [
+  {files: ["**/*.{js,mjs,cjs,ts}"]},
+  {languageOptions: { globals: globals.browser }},
+  pluginJs.configs.recommended,
+  ...tseslint.configs.recommended,
+];

--- a/extension.ts
+++ b/extension.ts
@@ -1,65 +1,92 @@
-import { Facet, Extension, RangeSet } from "@codemirror/state"
-import { WidgetType, EditorView, Decoration, ViewPlugin, DecorationSet, ViewUpdate, MatchDecorator } from "@codemirror/view"
+import { Facet, Extension, RangeSet } from '@codemirror/state';
+import {
+	WidgetType,
+	EditorView,
+	Decoration,
+	ViewPlugin,
+	DecorationSet,
+	ViewUpdate,
+	MatchDecorator,
+} from '@codemirror/view';
 
 interface MorgenPluginSettings {
-	decorateIDs: 'show' | 'hide' | 'replace_with_emoji'
+	decorateIDs: 'show' | 'hide' | 'replace_with_emoji';
 }
 
 const DEFAULT_SETTINGS: MorgenPluginSettings = {
-	decorateIDs: 'show'
-}
+	decorateIDs: 'show',
+};
 
 class IDWidget extends WidgetType {
-	constructor(readonly id: string) { super() }
+	constructor(readonly id: string) {
+		super();
+	}
 
 	toDOM() {
-		const wrap = document.createElement("span")
-		wrap.setAttribute("aria-label", `ID: ${this.id}`)
-		const box = wrap.appendChild(document.createElement("span"))
-		box.innerText = "▫️";
+		const wrap = document.createElement('span');
+		wrap.setAttribute('aria-label', `ID: ${this.id}`);
+		const box = wrap.appendChild(document.createElement('span'));
+		box.innerText = '▫️';
 		box.style.opacity = '0.7';
 		box.style.filter = 'grayscale()';
-		return wrap
+		return wrap;
 	}
 }
 
-
 const settingsFacet = Facet.define<MorgenPluginSettings, MorgenPluginSettings>({
-  combine: allSettings => allSettings[0] ?? DEFAULT_SETTINGS
-})
+	combine: (allSettings) => allSettings[0] ?? DEFAULT_SETTINGS,
+});
 
 function hideIdsDeco(view: EditorView): DecorationSet {
 	return new MatchDecorator({
 		regexp: /🆔 ([A-Za-z0-9]+)/g,
-		decoration: match => {
+		decoration: (match) => {
 			return Decoration.replace({
-				widget: view.state.facet(settingsFacet).decorateIDs === "hide" ? undefined : new IDWidget(match[1]),
-			})
-		}
+				widget:
+					view.state.facet(settingsFacet).decorateIDs === 'hide'
+						? undefined
+						: new IDWidget(match[1]),
+			});
+		},
 	}).createDeco(view);
 }
 
-const hideIDsPlugin = ViewPlugin.fromClass(class {
-	decorations: DecorationSet;
-	placeholderMatcher: MatchDecorator;
-	previousSettingsHash: string;
+const hideIDsPlugin = ViewPlugin.fromClass(
+	class {
+		decorations: DecorationSet;
+		placeholderMatcher: MatchDecorator;
+		previousSettingsHash: string;
 
-	constructor(view: EditorView) {
-		this.previousSettingsHash = JSON.stringify(view.state.facet(settingsFacet));
-
-		this.decorations = view.state.facet(settingsFacet).decorateIDs === "show" ? RangeSet.empty : hideIdsDeco(view);
-	}
-
-	update(update: ViewUpdate) {
-		if (update.docChanged || this.previousSettingsHash !== JSON.stringify(update.view.state.facet(settingsFacet))) {
-			this.previousSettingsHash = JSON.stringify(update.view.state.facet(settingsFacet));
-			this.decorations = update.view.state.facet(settingsFacet).decorateIDs === "show" ? RangeSet.empty : hideIdsDeco(update.view);
+		constructor(view: EditorView) {
+			this.previousSettingsHash = JSON.stringify(view.state.facet(settingsFacet));
+			this.decorations =
+				view.state.facet(settingsFacet).decorateIDs === 'show'
+					? RangeSet.empty
+					: hideIdsDeco(view);
 		}
-	}
-}, {
-	decorations: v => v.decorations,
-	provide: plugin => EditorView.atomicRanges.of(view => view.plugin(plugin)?.decorations || Decoration.none)
-})
 
-export function hideIDsExtension(settings: MorgenPluginSettings = DEFAULT_SETTINGS): Extension { return [ settingsFacet.of(settings), hideIDsPlugin ] }
+		update(update: ViewUpdate) {
+			if (
+				update.docChanged ||
+				this.previousSettingsHash !== JSON.stringify(update.view.state.facet(settingsFacet))
+			) {
+				this.previousSettingsHash = JSON.stringify(update.view.state.facet(settingsFacet));
+				this.decorations =
+					update.view.state.facet(settingsFacet).decorateIDs === 'show'
+						? RangeSet.empty
+						: hideIdsDeco(update.view);
+			}
+		}
+	},
+	{
+		decorations: (v) => v.decorations,
+		provide: (plugin) =>
+			EditorView.atomicRanges.of(
+				(view) => view.plugin(plugin)?.decorations || Decoration.none,
+			),
+	},
+);
 
+export function hideIDsExtension(settings: MorgenPluginSettings = DEFAULT_SETTINGS): Extension {
+	return [settingsFacet.of(settings), hideIDsPlugin];
+}

--- a/main.ts
+++ b/main.ts
@@ -45,7 +45,13 @@ export default class MorgenPlugin extends Plugin {
 		 */
 		this.registerEditorExtension(hideIDsExtension(this.settings));
 		this.postProcessor = new MorgenTasksPostProcessor(this.settings);
-		this.registerMarkdownPostProcessor((element) => this.postProcessor.postProcess(element));
+		this.registerMarkdownPostProcessor((element) => {
+			try {
+				this.postProcessor.postProcess(element);
+			} catch (e: unknown) {
+				console.error('MorgenPlugin: Error whilst post processing markdown', e);
+			}
+		});
 
 		this.addSettingTab(new MorgenSettingTab(this.app, this));
 	}

--- a/main.ts
+++ b/main.ts
@@ -2,9 +2,8 @@ import { App, Plugin, PluginSettingTab, Setting } from 'obsidian';
 
 import { hideIDsExtension } from 'extension';
 
-interface MorgenPluginSettings {
-	decorateIDs: 'show' | 'hide' | 'replace_with_emoji';
-}
+import { MorgenTasksPostProcessor } from 'postProcessor';
+import { MorgenPluginSettings } from 'settings';
 
 const DEFAULT_SETTINGS: MorgenPluginSettings = {
 	decorateIDs: 'show',
@@ -12,11 +11,41 @@ const DEFAULT_SETTINGS: MorgenPluginSettings = {
 
 export default class MorgenPlugin extends Plugin {
 	settings: MorgenPluginSettings;
+	postProcessor: MorgenTasksPostProcessor;
 
 	async onload() {
 		await this.loadSettings();
 
+		/*
+		 * Explanation of how the ID hiding works:
+		 *
+		 * There are two modes to consider:
+		 *  - editing mode (handled entirely by a CodeMirror Editor extension (hideIDsExtension)
+		 *  - reading mode
+		 *    - read-only view, which can be enabled whilst viewing any note in Obsidian
+		 *    - also enabled for cards visible in the Kanban plugin board view
+		 *
+		 * Editing mode: see extension.ts. This is a CodeMirror extension that
+		 * uses a decorator to effectively replace any text that matches the ID
+		 * Regex with an emoji or nil. This is the one that gets a nicer
+		 * tooltip on hover.
+		 *
+		 * Reading mode: A lot of the work is done by style.css, which hides
+		 * elements by matching the appropriate elements created by markdown
+		 * post-processing that already happened in the Kanban and Tasks
+		 * plugins. There are some cases where task IDs do not have an obvious
+		 * containing span element that can be easily replaced/hidden. These
+		 * are handled by the MorgenTasksPostProcessor:
+		 *   - Tasks plugin has a bug that causes IDs that have text after them
+		 *     in the line to NOT get a container span, which is normally handled
+		 *     by the style.css rules
+		 *   - Kanban plugin by default shows tasks in "inline" mode, which is
+		 *     an alternative to "Move task data to card footer". It does not
+		 *     wrap the ID in a containing span.
+		 */
 		this.registerEditorExtension(hideIDsExtension(this.settings));
+		this.postProcessor = new MorgenTasksPostProcessor(this.settings);
+		this.registerMarkdownPostProcessor((element) => this.postProcessor.postProcess(element));
 
 		this.addSettingTab(new MorgenSettingTab(this.app, this));
 	}
@@ -25,11 +54,19 @@ export default class MorgenPlugin extends Plugin {
 
 	async updateSettings(update: Partial<MorgenPluginSettings>) {
 		Object.assign(this.settings, update);
+		document.documentElement.style.setProperty(
+			'--morgen-tasks-decorate-ids',
+			this.settings.decorateIDs,
+		);
 		return this.saveSettings();
 	}
 
 	async loadSettings() {
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+		document.documentElement.style.setProperty(
+			'--morgen-tasks-decorate-ids',
+			this.settings.decorateIDs,
+		);
 	}
 
 	async saveSettings() {

--- a/main.ts
+++ b/main.ts
@@ -3,12 +3,12 @@ import { App, Plugin, PluginSettingTab, Setting } from 'obsidian';
 import { hideIDsExtension } from 'extension';
 
 interface MorgenPluginSettings {
-	decorateIDs: 'show' | 'hide' | 'replace_with_emoji'
+	decorateIDs: 'show' | 'hide' | 'replace_with_emoji';
 }
 
 const DEFAULT_SETTINGS: MorgenPluginSettings = {
-	decorateIDs: 'show'
-}
+	decorateIDs: 'show',
+};
 
 export default class MorgenPlugin extends Plugin {
 	settings: MorgenPluginSettings;
@@ -21,11 +21,11 @@ export default class MorgenPlugin extends Plugin {
 		this.addSettingTab(new MorgenSettingTab(this.app, this));
 	}
 
-	onunload() { }
+	onunload() {}
 
 	async updateSettings(update: Partial<MorgenPluginSettings>) {
 		Object.assign(this.settings, update);
-		return this.saveSettings()
+		return this.saveSettings();
 	}
 
 	async loadSettings() {
@@ -46,22 +46,24 @@ class MorgenSettingTab extends PluginSettingTab {
 	}
 
 	display(): void {
-		const {containerEl} = this;
+		const { containerEl } = this;
 
 		containerEl.empty();
 
 		new Setting(containerEl)
 			.setName('Enabled task ID hiding')
 			.setDesc('Hide all IDs in your note to reduce noise')
-		.addDropdown((component) => {
-			component
-			.addOptions({
-				replace_with_emoji: 'Replace with emoji',
-				hide: 'Hide completely',
-				show: 'Show IDs',
-			})
-			.setValue(this.plugin.settings.decorateIDs)
-			.onChange((value: typeof this.plugin.settings.decorateIDs) => this.plugin.updateSettings({decorateIDs : value}))
-		})
+			.addDropdown((component) => {
+				component
+					.addOptions({
+						replace_with_emoji: 'Replace with emoji',
+						hide: 'Hide completely',
+						show: 'Show IDs',
+					})
+					.setValue(this.plugin.settings.decorateIDs)
+					.onChange((value: typeof this.plugin.settings.decorateIDs) =>
+						this.plugin.updateSettings({ decorateIDs: value }),
+					);
+			});
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,14 +12,19 @@
 				"@codemirror/language": "^6.10.2"
 			},
 			"devDependencies": {
+				"@eslint/js": "^9.10.0",
 				"@types/node": "^16.11.6",
 				"@typescript-eslint/eslint-plugin": "5.29.0",
 				"@typescript-eslint/parser": "5.29.0",
 				"builtin-modules": "3.3.0",
 				"esbuild": "0.17.3",
+				"eslint": "^8.57.1",
+				"globals": "^15.9.0",
 				"obsidian": "latest",
+				"prettier": "3.3.3",
 				"tslib": "2.4.0",
-				"typescript": "4.7.4"
+				"typescript": "4.7.4",
+				"typescript-eslint": "^8.6.0"
 			}
 		},
 		"node_modules/@codemirror/language": {
@@ -407,7 +412,6 @@
 			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
 			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"eslint-visitor-keys": "^3.3.0"
 			},
@@ -419,11 +423,10 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.10.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.1.tgz",
-			"integrity": "sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==",
+			"version": "4.11.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
+			"integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
@@ -433,7 +436,6 @@
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
 			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -452,25 +454,38 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/@eslint/js": {
-			"version": "8.57.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
-			"integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+		"node_modules/@eslint/eslintrc/node_modules/globals": {
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 			"dev": true,
-			"peer": true,
+			"dependencies": {
+				"type-fest": "^0.20.2"
+			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@eslint/js": {
+			"version": "9.10.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.10.0.tgz",
+			"integrity": "sha512-fuXtbiP5GWIn8Fz+LWoOMVf/Jxm+aajZYkhi6CuEm4SxymFM+eUWzbO9qXT+L0iCkL5+KGYMCSGxo686H19S1g==",
+			"dev": true,
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.11.14",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
-			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+			"integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
 			"deprecated": "Use @eslint/config-array instead",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
-				"@humanwhocodes/object-schema": "^2.0.2",
+				"@humanwhocodes/object-schema": "^2.0.3",
 				"debug": "^4.3.1",
 				"minimatch": "^3.0.5"
 			},
@@ -483,7 +498,6 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
 			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=12.22"
 			},
@@ -497,8 +511,7 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
 			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
 			"deprecated": "Use @eslint/object-schema instead",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@lezer/common": {
 			"version": "1.2.1",
@@ -780,15 +793,13 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
 			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/acorn": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
-			"integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
+			"version": "8.12.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+			"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -801,7 +812,6 @@
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"dev": true,
-			"peer": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
@@ -811,7 +821,6 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -828,7 +837,6 @@
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -838,7 +846,6 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -853,8 +860,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
@@ -869,15 +875,13 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -912,7 +916,6 @@
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -922,7 +925,6 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -939,7 +941,6 @@
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -951,22 +952,19 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
 			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -997,8 +995,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
@@ -1017,7 +1014,6 @@
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
 			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"esutils": "^2.0.2"
 			},
@@ -1067,7 +1063,6 @@
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -1076,17 +1071,16 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.57.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
-			"integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+			"integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
 				"@eslint/eslintrc": "^2.1.4",
-				"@eslint/js": "8.57.0",
-				"@humanwhocodes/config-array": "^0.11.14",
+				"@eslint/js": "8.57.1",
+				"@humanwhocodes/config-array": "^0.13.0",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
 				"@ungap/structured-clone": "^1.2.0",
@@ -1183,12 +1177,20 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/eslint/node_modules/@eslint/js": {
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+			"integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
 		"node_modules/eslint/node_modules/eslint-scope": {
 			"version": "7.2.2",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
 			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
@@ -1205,9 +1207,23 @@
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=4.0"
+			}
+		},
+		"node_modules/eslint/node_modules/globals": {
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+			"dev": true,
+			"dependencies": {
+				"type-fest": "^0.20.2"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/espree": {
@@ -1215,7 +1231,6 @@
 			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
 			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"acorn": "^8.9.0",
 				"acorn-jsx": "^5.3.2",
@@ -1233,7 +1248,6 @@
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
 			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
@@ -1246,7 +1260,6 @@
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -1286,7 +1299,6 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1295,8 +1307,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/fast-glob": {
 			"version": "3.3.2",
@@ -1330,15 +1341,13 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/fastq": {
 			"version": "1.17.1",
@@ -1354,7 +1363,6 @@
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
 			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"flat-cache": "^3.0.4"
 			},
@@ -1379,7 +1387,6 @@
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -1396,7 +1403,6 @@
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
 			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"flatted": "^3.2.9",
 				"keyv": "^4.5.3",
@@ -1410,15 +1416,13 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
 			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/functional-red-black-tree": {
 			"version": "1.0.1",
@@ -1432,7 +1436,6 @@
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 			"deprecated": "Glob versions prior to v9 are no longer supported",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -1453,7 +1456,6 @@
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
 			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"is-glob": "^4.0.3"
 			},
@@ -1462,16 +1464,12 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "13.24.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+			"version": "15.9.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-15.9.0.tgz",
+			"integrity": "sha512-SmSKyLLKFbSr6rptvP8izbyxJL4ILwqO9Jg23UA0sDlGlu58V59D1//I3vlc0KJphVdUR7vMjHIplYnzBxorQA==",
 			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -1501,15 +1499,13 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -1528,7 +1524,6 @@
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
 			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
@@ -1545,7 +1540,6 @@
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.8.19"
 			}
@@ -1556,7 +1550,6 @@
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
 			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -1566,8 +1559,7 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
@@ -1604,7 +1596,6 @@
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -1613,15 +1604,13 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -1633,29 +1622,25 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
 			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
 			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"json-buffer": "3.0.1"
 			}
@@ -1665,7 +1650,6 @@
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
 			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
@@ -1679,7 +1663,6 @@
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"p-locate": "^5.0.0"
 			},
@@ -1694,8 +1677,7 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -1724,7 +1706,6 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -1751,8 +1732,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/obsidian": {
 			"version": "1.5.7-1",
@@ -1773,7 +1753,6 @@
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"wrappy": "1"
 			}
@@ -1783,7 +1762,6 @@
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
 			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
@@ -1801,7 +1779,6 @@
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
 			},
@@ -1817,7 +1794,6 @@
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
@@ -1833,7 +1809,6 @@
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"callsites": "^3.0.0"
 			},
@@ -1846,7 +1821,6 @@
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -1856,7 +1830,6 @@
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1866,7 +1839,6 @@
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -1897,9 +1869,23 @@
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/prettier": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+			"integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+			"dev": true,
+			"bin": {
+				"prettier": "bin/prettier.cjs"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
 		"node_modules/punycode": {
@@ -1907,7 +1893,6 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -1949,7 +1934,6 @@
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -1970,7 +1954,6 @@
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 			"deprecated": "Rimraf versions prior to v4 are no longer supported",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -2021,7 +2004,6 @@
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
 			},
@@ -2034,7 +2016,6 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2053,7 +2034,6 @@
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -2066,7 +2046,6 @@
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -2084,7 +2063,6 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -2096,8 +2074,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -2109,6 +2086,18 @@
 			},
 			"engines": {
 				"node": ">=8.0"
+			}
+		},
+		"node_modules/ts-api-utils": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+			"integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.2.0"
 			}
 		},
 		"node_modules/tslib": {
@@ -2143,7 +2132,6 @@
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
 			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1"
 			},
@@ -2156,7 +2144,6 @@
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -2177,12 +2164,240 @@
 				"node": ">=4.2.0"
 			}
 		},
+		"node_modules/typescript-eslint": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.6.0.tgz",
+			"integrity": "sha512-eEhhlxCEpCd4helh3AO1hk0UP2MvbRi9CtIAJTVPQjuSXOOO2jsEacNi4UdcJzZJbeuVg1gMhtZ8UYb+NFYPrA==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/eslint-plugin": "8.6.0",
+				"@typescript-eslint/parser": "8.6.0",
+				"@typescript-eslint/utils": "8.6.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.6.0.tgz",
+			"integrity": "sha512-UOaz/wFowmoh2G6Mr9gw60B1mm0MzUtm6Ic8G2yM1Le6gyj5Loi/N+O5mocugRGY+8OeeKmkMmbxNqUCq3B4Sg==",
+			"dev": true,
+			"dependencies": {
+				"@eslint-community/regexpp": "^4.10.0",
+				"@typescript-eslint/scope-manager": "8.6.0",
+				"@typescript-eslint/type-utils": "8.6.0",
+				"@typescript-eslint/utils": "8.6.0",
+				"@typescript-eslint/visitor-keys": "8.6.0",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.3.1",
+				"natural-compare": "^1.4.0",
+				"ts-api-utils": "^1.3.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+				"eslint": "^8.57.0 || ^9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.6.0.tgz",
+			"integrity": "sha512-eQcbCuA2Vmw45iGfcyG4y6rS7BhWfz9MQuk409WD47qMM+bKCGQWXxvoOs1DUp+T7UBMTtRTVT+kXr7Sh4O9Ow==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "8.6.0",
+				"@typescript-eslint/types": "8.6.0",
+				"@typescript-eslint/typescript-estree": "8.6.0",
+				"@typescript-eslint/visitor-keys": "8.6.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.6.0.tgz",
+			"integrity": "sha512-ZuoutoS5y9UOxKvpc/GkvF4cuEmpokda4wRg64JEia27wX+PysIE9q+lzDtlHHgblwUWwo5/Qn+/WyTUvDwBHw==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "8.6.0",
+				"@typescript-eslint/visitor-keys": "8.6.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/type-utils": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.6.0.tgz",
+			"integrity": "sha512-dtePl4gsuenXVwC7dVNlb4mGDcKjDT/Ropsk4za/ouMBPplCLyznIaR+W65mvCvsyS97dymoBRrioEXI7k0XIg==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/typescript-estree": "8.6.0",
+				"@typescript-eslint/utils": "8.6.0",
+				"debug": "^4.3.4",
+				"ts-api-utils": "^1.3.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/types": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.6.0.tgz",
+			"integrity": "sha512-rojqFZGd4MQxw33SrOy09qIDS8WEldM8JWtKQLAjf/X5mGSeEFh5ixQlxssMNyPslVIk9yzWqXCsV2eFhYrYUw==",
+			"dev": true,
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.6.0.tgz",
+			"integrity": "sha512-MOVAzsKJIPIlLK239l5s06YXjNqpKTVhBVDnqUumQJja5+Y94V3+4VUFRA0G60y2jNnTVwRCkhyGQpavfsbq/g==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "8.6.0",
+				"@typescript-eslint/visitor-keys": "8.6.0",
+				"debug": "^4.3.4",
+				"fast-glob": "^3.3.2",
+				"is-glob": "^4.0.3",
+				"minimatch": "^9.0.4",
+				"semver": "^7.6.0",
+				"ts-api-utils": "^1.3.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.6.0.tgz",
+			"integrity": "sha512-eNp9cWnYf36NaOVjkEUznf6fEgVy1TWpE0o52e4wtojjBx7D1UV2WAWGzR+8Y5lVFtpMLPwNbC67T83DWSph4A==",
+			"dev": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@typescript-eslint/scope-manager": "8.6.0",
+				"@typescript-eslint/types": "8.6.0",
+				"@typescript-eslint/typescript-estree": "8.6.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.6.0.tgz",
+			"integrity": "sha512-wapVFfZg9H0qOYh4grNVQiMklJGluQrOUiOhYRrQWhx7BY/+I1IYb8BczWNbbUpO+pqy0rDciv3lQH5E1bCLrg==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "8.6.0",
+				"eslint-visitor-keys": "^3.4.3"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
@@ -2197,7 +2412,6 @@
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"isexe": "^2.0.0"
 			},
@@ -2213,7 +2427,6 @@
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
 			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2222,15 +2435,13 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},

--- a/package.json
+++ b/package.json
@@ -12,14 +12,19 @@
 	"author": "",
 	"license": "MIT",
 	"devDependencies": {
+		"@eslint/js": "^9.10.0",
 		"@types/node": "^16.11.6",
 		"@typescript-eslint/eslint-plugin": "5.29.0",
 		"@typescript-eslint/parser": "5.29.0",
 		"builtin-modules": "3.3.0",
 		"esbuild": "0.17.3",
+		"eslint": "^8.57.1",
+		"globals": "^15.9.0",
 		"obsidian": "latest",
+		"prettier": "3.3.3",
 		"tslib": "2.4.0",
-		"typescript": "4.7.4"
+		"typescript": "4.7.4",
+		"typescript-eslint": "^8.6.0"
 	},
 	"dependencies": {
 		"@codemirror/language": "^6.10.2"

--- a/postProcessor.ts
+++ b/postProcessor.ts
@@ -1,0 +1,69 @@
+import { MarkdownPostProcessor } from 'obsidian';
+import { MorgenPluginSettings } from 'settings';
+
+const taskIdRegex = /[a-zA-Z0-9-_]+/;
+const IDRegex = new RegExp('🆔 *(' + taskIdRegex.source + ')', 'iu');
+
+interface PostProcessor {
+	postProcess: MarkdownPostProcessor;
+}
+
+export class MorgenTasksPostProcessor implements PostProcessor {
+	private settings: MorgenPluginSettings;
+
+	constructor(settings: MorgenPluginSettings) {
+		this.settings = settings;
+	}
+
+	postProcess(element: HTMLElement) {
+		if (this.settings.decorateIDs === 'show') return;
+
+		const getReplacement = (id: string) => {
+			switch (this.settings.decorateIDs) {
+				case 'replace_with_emoji':
+					return element.createSpan({
+						text: '▫️',
+						title: id,
+					});
+				default:
+					return null;
+			}
+		};
+
+		const elementsWithIds: [HTMLElement, RegExpMatchArray][] = element
+			.findAll('p, span, li')
+			.map((container): [HTMLElement, RegExpMatchArray | null] => [
+				container,
+				container.innerText.match(IDRegex),
+			])
+			.filter((args) => args[1]) as [HTMLElement, RegExpMatchArray][];
+
+		for (const [el, match] of elementsWithIds) {
+			if (
+				// Task is rendered by the Tasks plugin by a query block. If
+				// the ID isn't the last item in the text, it will sometimes
+				// fail to give the ID its own span (which would normally be
+				// replaced by style.css). This is a work-around for that.
+				el.parentElement?.parentElement?.parentElement?.hasClass('tasks-list-text') ||
+				// Task is rendered inline by the Kanban plugin, which means
+				// the ID is present in an element containing the rest of the
+				// task description.
+				el.parentElement?.hasClass('kanban-plugin__markdown-preview-view')
+			) {
+				const [before, after] = el.innerText.split(match[0]);
+				const replacement = getReplacement(match[0]);
+
+				const replacementElement = element.createEl(
+					el.tagName as keyof HTMLElementTagNameMap,
+				);
+				replacementElement.className = el.className;
+				replacementElement.appendText(before);
+				if (replacement) {
+					replacementElement.appendChild(replacement);
+				}
+				replacementElement.appendText(after);
+				el.replaceWith(replacementElement);
+			}
+		}
+	}
+}

--- a/settings.d.ts
+++ b/settings.d.ts
@@ -1,0 +1,7 @@
+export interface MorgenPluginSettings {
+	/**
+	 * Whether to show/hide or replace text-based IDs in Tasks plugin tasks
+	 * with an emoji.
+	 */
+	decorateIDs: 'show' | 'hide' | 'replace_with_emoji';
+}

--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,25 @@
-/*
+@container style(--morgen-tasks-decorate-ids: hide) {
+	/** Hide ID spans completely in both Kanban and Tasks plugins */
+	.kanban-plugin__inline-metadata__id, .task-id {
+		display: none;
+	}
+}
 
-This CSS file will be included with your plugin, and
-available in the app when your plugin is enabled.
+@container style(--morgen-tasks-decorate-ids: replace_with_emoji) {
+	/** Replace ID spans with emoji in Tasks plugin */
+	.task-id {
+		font-size: 0pt;
+	}
 
-If your plugin does not need CSS, delete this file.
+	.task-id::before {
+		font-size: initial;
+		content: '▫️';
+	}
 
-*/
+	/** Hide IDs in Kanban plugin (doesn't make sense to use emoji here) */
+	.kanban-plugin__inline-metadata__id {
+		display: none;
+	}
+}
+
+


### PR DESCRIPTION
I will not squash these commits as the first is clearly unrelated and is purely related to formatting the codebase.

The second one is the one I would like a review of.

This fixes the problem where IDs were not hidden/replaced in:
 - reading mode
 - queries
 - Kanban boards (inline/card footer mode)

Screenshots previewing "replace with emoji" mode:

This first one is the outlier because it doesn't make much sense to replace the Kanban plugin ID card footer chip with an emoji, so it's just hidden in this mode.
![CleanShot 2024-09-23 at 15 09 09](https://github.com/user-attachments/assets/23d0f3ed-55af-4a01-a371-5b0b5c4d52da)

![CleanShot 2024-09-23 at 15 09 13](https://github.com/user-attachments/assets/f1fc31ba-d306-4c56-ad76-569997e31857)
![CleanShot 2024-09-23 at 15 09 20](https://github.com/user-attachments/assets/b39fa17a-b008-49de-af79-b7c9fe99bdd3)
![CleanShot 2024-09-23 at 15 09 43](https://github.com/user-attachments/assets/6e6cfffb-17a9-4114-84c2-2cf350e7236c)
